### PR TITLE
Properly set IP address to use for gNB and use integer for server index to align with gnbsim

### DIFF
--- a/config/custom-gnb.yaml
+++ b/config/custom-gnb.yaml
@@ -5,9 +5,9 @@ nci: '0x000000010'  # NR Cell Identity (36-bit)
 idLength: 32        # NR gNB ID length in bits [22...32]
 tac: 1              # Tracking Area Code
 
-linkIp: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}   # gNB's local IP address for Radio Link Simulation (Usually same with local IP)
-ngapIp: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}   # gNB's local IP address for N2 Interface (Usually same with local IP)
-gtpIp: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}    # gNB's local IP address for N3 Interface (Usually same with local IP)
+linkIp: {{ ueransim.gnb.ip }}   # gNB's local IP address for Radio Link Simulation (Usually same with local IP)
+ngapIp: {{ ueransim.gnb.ip }}   # gNB's local IP address for N2 Interface (Usually same with local IP)
+gtpIp: {{ ueransim.gnb.ip }}    # gNB's local IP address for N3 Interface (Usually same with local IP)
 
 # List of AMF address information
 amfConfigs:

--- a/config/custom-ue.yaml
+++ b/config/custom-ue.yaml
@@ -28,7 +28,7 @@ imeiSv: '4370816125816151'
 
 # List of gNB IP addresses for Radio Link Simulation
 gnbSearchList:
-  - {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+  - {{ ueransim.gnb.ip }}
 
 # UAC Access Identities Configuration
 uacAic:

--- a/roles/simulator/defaults/main.yml
+++ b/roles/simulator/defaults/main.yml
@@ -4,8 +4,11 @@ ueransim:
       macvlan:
         name: ueransimnet
 
+  gnb:
+    ip: "172.20.0.2"
+
   servers:
-    "0":
+    0:
       gnb: "config/custom-gnb.yaml"
       ue: "config/custom-ue.yaml"
 core:

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -7,18 +7,18 @@
 
 - name: copy gNb config files to ueransim host
   template:
-    src: "{{ ROOT_DIR }}/{{ ueransim.servers[server_index].gnb }}"
+    src: "{{ ROOT_DIR }}/{{ ueransim.servers[server_index | int].gnb }}"
     dest: ueransim_onramp/config/custom-gnb.yaml
   vars:
-    server_index: "{{ groups['ueransim_nodes'].index(inventory_hostname) }}"  
+    server_index: "{{ groups['ueransim_nodes'].index(inventory_hostname) }}"
   when: inventory_hostname in groups['ueransim_nodes']
 
 - name: copy UE config files to ueransim host
   template:
-    src: "{{ ROOT_DIR }}/{{ ueransim.servers[server_index].ue }}"
+    src: "{{ ROOT_DIR }}/{{ ueransim.servers[server_index | int].ue }}"
     dest: ueransim_onramp/config/custom-ue.yaml
   vars:
-    server_index: "{{ groups['ueransim_nodes'].index(inventory_hostname) }}"  
+    server_index: "{{ groups['ueransim_nodes'].index(inventory_hostname) }}"
   when: inventory_hostname in groups['ueransim_nodes']
 
 - name: Run gNB
@@ -61,17 +61,17 @@
   args:
     chdir: ueransim_onramp/build
   when: "inventory_hostname in groups['ueransim_nodes']"
-  
+
 - debug:
     var: ue_output.stdout_lines
   when: "inventory_hostname in groups['ueransim_nodes']"
 
-### TODO: IPERF 
+### TODO: IPERF
 
 # - name: Get information about the pod
 #   kubernetes.core.k8s_info:
 #     kind: Pod
-#     namespace: aether-5gc      
+#     namespace: aether-5gc
 #     name: iperf-server
 #   when: inventory_hostname in groups['master_nodes'][0]
 #   register: iperf_server_pod_info
@@ -96,6 +96,6 @@
 #     chdir: ueransim_onramp/build
 #   tags:
 #     - ueransim
-  
+
 # - debug:
 #     var: ue_output.stdout_lines

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,25 +5,9 @@ core:
     ip: "172.31.3.101"
 
 ueransim:
+  gnb:
+    ip: "172.20.0.2"
   servers:
-    "0":
+    0:
       gnb: "config/custom-gnb.yaml"
       ue: "config/custom-ue.yaml"
-  
-  # TODO: Dockerize UERANSIM  
-  # docker:
-  #   container:
-  #     image: kunal14kapoor/ueransim:latest
-  #     prefix: ueransim
-  #     count: 1
-  #   network:
-  #     macvlan:
-  #       name: ueransimnet
-
-      #servers: Enable this for different needed configurations.Please ensure the file existence.
-      #0:
-      #- "deps/ueransim/config/ueransim-s1-p1.yaml"
-      #- "deps/ueransim/config/ueransim-s1-p2.yaml"
-      #1:
-      #- "deps/ueransim/config/ueransim-s1-p2.yaml"
-      #- "deps/ueransim/config/ueransim-s1-p1.yaml"


### PR DESCRIPTION
This PR includes the following:
- Properly set the IP address to use for the gNB (Previous way to setting the IP address is not correct because it is ignoring the user's choice when the host has multiple interfaces and user decided to use a non-default interface)
- Use integer value as server index to align with what is done in the gnbsim repo