### PR TITLE
Add multihop support to deploy GNB's from multiple hops

### DIFF
--- a/roles/simulator/defaults/main.yml
+++ b/roles/simulator/defaults/main.yml
@@ -12,5 +12,7 @@ ueransim:
       gnb: "config/custom-gnb.yaml"
       ue: "config/custom-ue.yaml"
 core:
+  upf:
+    multihop_gnb: false
   amf:
     ip: "172.16.248.6"

--- a/roles/simulator/tasks/install.yml
+++ b/roles/simulator/tasks/install.yml
@@ -60,7 +60,7 @@
   shell: |
     ip route add {{ subnet }} via {{ core.amf.ip }}
   become: true
-  when: (inventory_hostname in groups['ueransim_nodes']) and (inventory_hostname not in groups['master_nodes'])
+  when: (inventory_hostname in groups['ueransim_nodes']) and (inventory_hostname not in groups['master_nodes']) and core.upf.multihop_gnb == false
 
 ### TODO: IPERF 
 

--- a/roles/simulator/tasks/uninstall.yml
+++ b/roles/simulator/tasks/uninstall.yml
@@ -26,6 +26,6 @@
 - name: remove static route for upf traffic on ueransim node
   shell: |
     ip route del {{ subnet }} via {{ core.amf.ip }}
-  when: (inventory_hostname in groups['ueransim_nodes']) and (inventory_hostname not in groups['master_nodes'])
+  when: (inventory_hostname in groups['ueransim_nodes']) and (inventory_hostname not in groups['master_nodes']) and core.upf.multihop_gnb == false
   become: true
   ignore_errors: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 core:
   upf:
     ip_prefix: "192.168.252.0/24"
+    multihop_gnb: false
   amf:
     ip: "172.31.3.101"
 


### PR DESCRIPTION
By default onramp deploys UPF using isolated N3/N6 networks (192.168.252.x/192.168.250.x) respectively. But in most customer deployments the GNB's will be deployed on different subnets than the access subnets. In such cases the current deployment will not work. So we have to deploy the access n/w (N3) using the same subnet as host DATA_IFACE.

For example,
DATA_IFACE = 10.21.61.x
upf_access_interface = 10.21.61.y

GNB subnet: 10.202.1.x

In this case, the GNB's deployed on different subnets can directly access UPF N3 interface (10.21.61.y) using the existing networking. But if we use the isolated access network (like 192.168.252.x) then the traffic from GNB's cannot reach UPF.

This solution helps deploy GNB's in same subnet and different subnets. Please note that by default still onramp uses the isolated n/w deployment (current behavior). Our mechanism will be used only if user sets multihop_gnb to true in vars/main.yml.