### PR TITLE
Improve UERANSIM blueprint by adding a stop task and update the start task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ export HOSTS_INI_FILE ?= hosts.ini
 export EXTRA_VARS ?= ""
 
 #### Start Ansible ####
-
 ueransim-ansible:
 	export ANSIBLE_NAME=$(ANSIBLE_NAME); \
 	sh $(UERANSIM_ROOT_DIR)/scripts/ansible ssh-agent bash
@@ -17,20 +16,24 @@ ueransim-ansible:
 #### a. Debugging ####
 ueransim-pingall:
 	ansible-playbook -i $(HOSTS_INI_FILE) $(UERANSIM_ROOT_DIR)/pingall.yml \
-	--extra-vars $(EXTRA_VARS)
+		--extra-vars $(EXTRA_VARS)
 
 #### b. Provision ueransim ####
 ueransim-install:
 	ansible-playbook -i $(HOSTS_INI_FILE) $(UERANSIM_ROOT_DIR)/simulator.yml --tags install \
-                --extra-vars "ROOT_DIR=$(ROOT_DIR)"  --extra-vars $(EXTRA_VARS) -v
+		--extra-vars "ROOT_DIR=$(ROOT_DIR)"  --extra-vars $(EXTRA_VARS) -v
 
 #### c. Start the simulator
 ueransim-run:
 	ansible-playbook -i $(HOSTS_INI_FILE) $(UERANSIM_ROOT_DIR)/simulator.yml --tags start  \
 		--extra-vars "ROOT_DIR=$(ROOT_DIR)"  --extra-vars $(EXTRA_VARS)
 
-#### d. Remove ueransim ####
-ueransim-uninstall:
+#### d. Stop the simulator
+ueransim-stop:
+	ansible-playbook -i $(HOSTS_INI_FILE) $(UERANSIM_ROOT_DIR)/simulator.yml --tags stop  \
+		--extra-vars "ROOT_DIR=$(ROOT_DIR)"  --extra-vars $(EXTRA_VARS)
+
+#### e. Remove ueransim ####
+ueransim-uninstall: ueransim-stop
 	ansible-playbook -i $(HOSTS_INI_FILE) $(UERANSIM_ROOT_DIR)/simulator.yml --tags uninstall  \
 		--extra-vars "ROOT_DIR=$(ROOT_DIR)"   --extra-vars $(EXTRA_VARS)
-

--- a/roles/simulator/tasks/main.yml
+++ b/roles/simulator/tasks/main.yml
@@ -8,6 +8,10 @@
   import_tasks: roles/simulator/tasks/start.yml
   tags: start
 
+- name: stop ueransim/simulator
+  import_tasks: roles/simulator/tasks/stop.yml
+  tags: stop
+
 - name: uninstall ueransim/simulator
   import_tasks: roles/simulator/tasks/uninstall.yml
   tags: uninstall

--- a/roles/simulator/tasks/start.yml
+++ b/roles/simulator/tasks/start.yml
@@ -55,8 +55,12 @@
     var: ue_ip
   when: inventory_hostname in groups['ueransim_nodes']
 
-- name: Run curl command for connectivity
-  shell: "./nr-binder {{ ue_ip }} curl google.com"
+- set_fact:
+    ping_target: "{{ core.upf.core_subnet | regex_replace('(/.*$)', '') }}"
+  when: "inventory_hostname in groups['ueransim_nodes']"
+
+- name: Run ping command for connectivity
+  shell: "./nr-binder {{ ue_ip }} ping -c 5 {{ ping_target }}"
   register: ue_output
   args:
     chdir: ueransim_onramp/build
@@ -65,37 +69,3 @@
 - debug:
     var: ue_output.stdout_lines
   when: "inventory_hostname in groups['ueransim_nodes']"
-
-### TODO: IPERF
-
-# - name: Get information about the pod
-#   kubernetes.core.k8s_info:
-#     kind: Pod
-#     namespace: aether-5gc
-#     name: iperf-server
-#   when: inventory_hostname in groups['master_nodes'][0]
-#   register: iperf_server_pod_info
-
-# - name: Set fact for Pod IP on master node
-#   set_fact:
-#     iperf_server_pod_ip: "{{ iperf_server_pod_info.resources[0].status.podIP }}"
-#   when: inventory_hostname in groups['master_nodes'][0]
-
-# - name: Print the Pod IP
-#   debug:
-#     msg: "Pod IP: ./nr-binder {{ ue_ip }} iperf -c {{ hostvars[item].iperf_server_pod_ip}}"
-#   with_items: "{{ groups['master_nodes'][0] }}"
-#   when: inventory_hostname in groups['ueransim_nodes']
-
-# - name: Run curl command for connectivity
-#   shell: "./nr-binder {{ ue_ip }} iperf -c {{ iperf_server_pod_ip }}"
-#   when: "inventory_hostname in groups['ueransim_nodes']"
-#   register: ue_output
-#   when: inventory_hostname in groups['ueransim_nodes']
-#   args:
-#     chdir: ueransim_onramp/build
-#   tags:
-#     - ueransim
-
-# - debug:
-#     var: ue_output.stdout_lines

--- a/roles/simulator/tasks/stop.yml
+++ b/roles/simulator/tasks/stop.yml
@@ -1,0 +1,12 @@
+---
+- name: force stop UE
+  command: pkill -9 -f nr-ue
+  when: inventory_hostname in groups['ueransim_nodes']
+  become: true
+  ignore_errors: yes
+
+- name: force stop gNB
+  command: pkill -9 -f nr-gnb
+  when: inventory_hostname in groups['ueransim_nodes']
+  become: true
+  ignore_errors: yes

--- a/roles/simulator/tasks/uninstall.yml
+++ b/roles/simulator/tasks/uninstall.yml
@@ -1,24 +1,12 @@
 ---
-- name: force stop gNB
-  command: pkill -9 -f nr-gnb
-  ignore_errors: yes
-  become: true
-  when: inventory_hostname in groups['ueransim_nodes']
-
-- name: force stop UE
-  command: pkill -9 -f nr-ue
-  ignore_errors: yes
-  become: true
-  when: inventory_hostname in groups['ueransim_nodes']
-
 - name: remove UERANSIM
   file:
     path: ueransim_onramp
     state: absent
   ignore_errors: yes
-  become: true  
+  become: true
   when: inventory_hostname in groups['ueransim_nodes']
-  
+
 - set_fact:
     subnet: "{{ core.upf.access_subnet | regex_replace('[0-9]+/24', '0/24') }}"
   when: inventory_hostname in groups['ueransim_nodes']


### PR DESCRIPTION
This PR does the following:

- Updates the `start` task to run ping instead of curl such that all blueprints run the same test/command
- Adds `stop` task such that there is no need to remove the entire blueprint installation if someone wants to reuse the deployment/installation
- Updates the `uninstall` task to stop UERANSIM processes and then remove the installation directory
- The changes were testing using a 2-system deployment (one for the SD-Core and another one for UERANSIM)
 
```
TASK [simulator : debug] ***********************************************************************************************
ok: [node2] => {
    "ue_output.stdout_lines": [
        "PING 192.168.250.1 (192.168.250.1) 56(84) bytes of data.",
        "64 bytes from 192.168.250.1: icmp_seq=1 ttl=64 time=3.30 ms",
        "64 bytes from 192.168.250.1: icmp_seq=2 ttl=64 time=3.08 ms",
        "64 bytes from 192.168.250.1: icmp_seq=3 ttl=64 time=2.86 ms",
        "64 bytes from 192.168.250.1: icmp_seq=4 ttl=64 time=2.93 ms",
        "64 bytes from 192.168.250.1: icmp_seq=5 ttl=64 time=3.01 ms",
        "",
        "--- 192.168.250.1 ping statistics ---",
        "5 packets transmitted, 5 received, 0% packet loss, time 4006ms",
        "rtt min/avg/max/mdev = 2.860/3.035/3.297/0.149 ms"
    ]
}
```